### PR TITLE
patient name design fix by adding zero padding

### DIFF
--- a/addons/web/static/src/scss/form_view.scss
+++ b/addons/web/static/src/scss/form_view.scss
@@ -14,6 +14,9 @@
     .oe_grey {
         opacity: 0.5;
     }
+    .btn-link {
+        padding: 0;
+    }
     .oe_inline {
         width: auto!important;
         @include media-breakpoint-up(vsm, $o-extra-grid-breakpoints) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Patient name design in form views fixed by adding zero padding.

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
